### PR TITLE
micro optimization

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -2535,10 +2535,12 @@ sub _do_kid_and_exit {
    eval {
       local $cur_self = $self;
 
-      _set_child_debug_name( ref $kid->{VAL} eq "CODE"
-	 ? "CODE"
-	 : basename( $kid->{VAL}->[0] )
-      );
+      if ( _debugging ) {
+         _set_child_debug_name( ref $kid->{VAL} eq "CODE"
+         	 ? "CODE"
+         	 : basename( $kid->{VAL}->[0] )
+         );
+      }
 
       ## close parent FD's first so they're out of the way.
       ## Don't close STDIN, STDOUT, STDERR: they should be inherited or
@@ -2643,9 +2645,10 @@ sub _do_kid_and_exit {
 	    fcntl $s2, F_SETFD, 1;
 	 }
 
-	 my @cmd = ( $kid->{PATH}, @{$kid->{VAL}}[1..$#{$kid->{VAL}}] );
-	 _debug 'execing ', join " ", map { /[\s\"]/ ? "'$_'" : $_ } @cmd
-	    if _debugging;
+	 if ( _debugging ) {
+	    my @cmd = ( $kid->{PATH}, @{$kid->{VAL}}[1..$#{$kid->{VAL}}] );
+	    _debug 'execing ', join " ", map { /[\s\"]/ ? "'$_'" : $_ } @cmd;
+	 }
 
 	 die "exec failed: simulating exec() failure"
 	    if $self->{_simulate_exec_failure};


### PR DESCRIPTION
Some micro optimizations to IPC::Run. With these two commits the test script below runs somewhat faster, about 10% on my system:

```
srezic-micro-optimization: env IPCRUNDEBUG=none perl -Mblib /tmp/ipc-run-1000.pl 
2.83188390731812
master:                    env IPCRUNDEBUG=none perl -Mblib /tmp/ipc-run-1000.pl 
3.12365984916687

srezic-micro-optimization: perl -Mblib /tmp/ipc-run-1000.pl                  
3.19277095794678
master:                    perl -Mblib /tmp/ipc-run-1000.pl 
3.4070770740509


 #!/usr/bin/perl

 use strict;
 use IPC::Run qw(run);
 use Time::HiRes qw(time);

 my $n = 1000;

 {
     my $t0 = time;
     run ['echo', 'foo'], '|', ['true']
    for 1..$n;
     warn time-$t0, "\n";
 }
 __END__
```
