### PR TITLE
Wrap an empty element of @$cmd with quotes, too.

### DIFF
--- a/lib/IPC/Run/Win32Helper.pm
+++ b/lib/IPC/Run/Win32Helper.pm
@@ -445,7 +445,7 @@ sub win32_spawn {
    my $process;
    my $cmd_line = join " ", map {
       ( my $s = $_ ) =~ s/"/"""/g;
-      $s = qq{"$s"} if /[\"\s]/;
+      $s = qq{"$s"} if /[\"\s]|^$/;
       $s;
    } @$cmd;
 


### PR DESCRIPTION
Since @$cmd is being turned into a string, all elements need to be
identifiable in the resulting string.  Similar to the case of an element
solely consisting of whitespace, an empty element needs to be quoted in
order to be properly represented in the resulting string.

Signed-off-by: James McCoy vega.james@gmail.com
