### PR TITLE
skip t/win32_compile.t on Android

### DIFF
--- a/t/win32_compile.t
+++ b/t/win32_compile.t
@@ -29,6 +29,11 @@ BEGIN {
        plan( skip_all => "perl5.00503's Socket.pm does not export IPPROTO_TCP" );
    }
 
+    if ( $^O eq 'android' ) {
+        plan( skip_all => "android does not support getprotobyname()" );
+    }
+
+
    $INC{$_} = 1 for qw( Win32/Process.pm Win32API/File.pm );
 
    package Win32API::File;


### PR DESCRIPTION
This is needed because IPC::Run::Win32IO uses getprotobyname(), which is not available on Android, and the test specifically modifies Socket::IPPROTO_TCP, which is present.
So rather than jump through hoops, just skip the test on android, which allows the module to install cleanly.
