### PR TITLE
Fix for run argument with spaces in path

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -1281,7 +1281,7 @@ sub _exec {
 #      # old values of $! causing spurious strerr()
 #      # messages to appear in the "Can't exec" message
 #      undef $!;
-      exec @_;
+      exec { $_[0] } @_;
 #   }
 #   croak "$!: exec( " . join( ', ', map "'$_'", @_ ) . " )";
     ## Fall through so $! can be reported to parent.


### PR DESCRIPTION
The first argument of `run` ends up being passed to the Perl built-in `exec`.  If the command has no arguments, then exec is only given a single argument, which is then possibly subject to shell interpretation,
which can break if the value contains spaces and other shell special characters.

Therefore, use the workaround described in the perlfunc man page of using an indirect object so that even a single-element argument list is not passed through the shell.

Fixes [RT 97926](https://rt.cpan.org/Public/Bug/Display.html?id=97926)
