### PR TITLE
exit(0) after we indicate we are skipping.

### DIFF
--- a/t/signal.t
+++ b/t/signal.t
@@ -25,6 +25,7 @@ use t::lib::Test;
 BEGIN {
 	if ( IPC::Run::Win32_MODE() ) {
 		plan skip_all => 'Skipping on Win32';
+		exit(0);
 	} else {
 		plan tests => 3;
 	}


### PR DESCRIPTION
may be enough to resolve rt ticket 100711.
https://rt.cpan.org/Ticket/Display.html?id=100711
plan skip_all => 'Skipping on Win32'; isn't sufficiently skipping.  exit(0);
