### PR TITLE
Use q{} and qq{} to fix problems with quotation in cmd.exe

### DIFF
--- a/t/binmode.t
+++ b/t/binmode.t
@@ -40,11 +40,11 @@ $nl_text =~ s/\r//g;
 
 my @perl    = ( $^X );
 
-my $emitter_script = q{ binmode STDOUT; print "Hello World\r\n" };
+my $emitter_script = q{ binmode STDOUT; print qq{Hello World\r\n} };
 my @emitter = ( @perl, '-e', $emitter_script );
 
 my $reporter_script =
-   q{ binmode STDIN; $_ = join "", <>; s/([\000-\037])/sprintf "\\\\0x%02x", ord $1/ge; print };
+   q{ binmode STDIN; $_ = join q{}, <>; s/([\000-\037])/sprintf qq{\\\\0x%02x}, ord $1/ge; print };
 my @reporter = ( @perl, '-e', $reporter_script );
 
 my $in;

--- a/t/run.t
+++ b/t/run.t
@@ -768,9 +768,9 @@ SKIP: {
    $err = 'REPLACE ME';
    $fd_map = _map_fds;
    $r = run(
-      [ @perl, '-lane', 'print STDERR "1:$_"; print uc($F[0])," ",$F[1]'],
-         \"Hello World",
-  '|',[ @perl, '-lane', 'print STDERR "2:$_"; print $F[0]," ",lc($F[1])'],
+      [ @perl, '-lane', 'print STDERR qq{1:$_}; print uc($F[0]), q{ },$F[1]'],
+         \q{Hello World},
+  '|',[ @perl, '-lane', 'print STDERR qq{2:$_}; print $F[0], q{ },lc($F[1])'],
 	 \$out,
 	 \$err,
    );
@@ -787,10 +787,10 @@ eok( $err, "1:Hello World\n2:HELLO World\n" );
    $err = 'REPLACE ME';
    $fd_map = _map_fds;
    $r = run(
-      [ @perl, '-lane', 'print STDERR "1:$_"; print uc($F[0])," ",$F[1]' ],
-         \"Hello World",
- '&', [ @perl, '-lane', 'print STDERR "2:$_"; print $F[0]," ",lc( $F[1] )' ],
-	 \"Hello World",
+      [ @perl, '-lane', 'print STDERR qq{1:$_}; print uc($F[0]),q{ },$F[1]' ],
+         \q{Hello World},
+ '&', [ @perl, '-lane', 'print STDERR "2:$_"; print $F[0],q{ },lc( $F[1] )' ],
+	 \q{Hello World},
 	 \$out,
 	 \$err,
    );


### PR DESCRIPTION
Use of `""` inside arguments passed to the interpreter via the shell caused the following test failures on my Windows 8.1 laptop with Visual Studio 2013 and perl 5.20.2. The fix is to use `q{}` and `qq{}` inside those arguments.

HTH,

-- Sinan

<pre>*prove -b t\binmode.t*
t\binmode.t .. 1/24 Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 67.

#   Failed test 'no binary'
#   at t\binmode.t line 68.
#          got: ''
#     expected: 'Hello World\0x0a'
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 70.

#   Failed test 'out binary'
#   at t\binmode.t line 71.
#          got: ''
#     expected: 'Hello World\0x0d\0x0a'
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 73.

#   Failed test 'out binary 0'
#   at t\binmode.t line 74.
#          got: ''
#     expected: 'Hello World\0x0a'
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 76.

#   Failed test 'out binary 1'
#   at t\binmode.t line 77.
#          got: ''
#     expected: 'Hello World\0x0d\0x0a'
String found where operator expected at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
        (Missing operator before ", <>; s/([\000-\037])/sprintf "?)
syntax error at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 80.

#   Failed test 'reporter < \n'
#   at t\binmode.t line 81.
#          got: ''
#     expected: 'Hello World\0x0d\0x0a'
String found where operator expected at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
        (Missing operator before ", <>; s/([\000-\037])/sprintf "?)
syntax error at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 83.

#   Failed test 'reporter < binary \n'
#   at t\binmode.t line 84.
#          got: ''
#     expected: 'Hello World\0x0a'
String found where operator expected at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
        (Missing operator before ", <>; s/([\000-\037])/sprintf "?)
syntax error at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 86.

#   Failed test 'reporter < binary \r\n'
#   at t\binmode.t line 87.
#          got: ''
#     expected: 'Hello World\0x0d\0x0a'
String found where operator expected at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
        (Missing operator before ", <>; s/([\000-\037])/sprintf "?)
syntax error at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 89.

#   Failed test 'reporter < binary(0) \n'
#   at t\binmode.t line 90.
#          got: ''
#     expected: 'Hello World\0x0d\0x0a'
String found where operator expected at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
        (Missing operator before ", <>; s/([\000-\037])/sprintf "?)
syntax error at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
Can't find string terminator '"' anywhere before EOF at -e line 1.

#   Failed test at t\binmode.t line 92.

#   Failed test 'reporter < binary(1) \n'
#   at t\binmode.t line 93.
#          got: ''
#     expected: 'Hello World\0x0a'
String found where operator expected at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
        (Missing operator before ", <>; s/([\000-\037])/sprintf "?)
syntax error at -e line 1, near """", <>; s/([\000-\037])/sprintf ""
Can't find string terminator '"' anywhere before EOF at -e line 1.
t\binmode.t .. 23/24
#   Failed test at t\binmode.t line 95.

#   Failed test 'reporter < binary(1) \r\n'
#   at t\binmode.t line 96.
#          got: ''
#     expected: 'Hello World\0x0d\0x0a'
# Looks like you failed 20 tests of 24.
t\binmode.t .. Dubious, test returned 20 (wstat 5120, 0x1400)
Failed 20/24 subtests

Test Summary Report
-------------------
t\binmode.t (Wstat: 5120 Tests: 24 Failed: 20)
  Failed tests:  5-24
  Non-zero exit status: 20
Files=1, Tests=24,  2 wallclock secs ( 0.08 usr +  0.03 sys =  0.11 CPU)
Result: FAIL
</pre>

<pre>*prove -b t\run.t*
t\run.t .. 163/268
#   Failed test at t\run.t line 777.

#   Failed test at t\run.t line 778.

#   Failed test 'eok at t\run.t line 780'
#   at t\run.t line 780.
#          got: ''
#     expected: 'HELLO world\0x0a'

#   Failed test 'eok at t\run.t line 781'
#   at t\run.t line 781.
#          got: 'Can't find string terminator '"' anywhere before EOF at -e line 1.\0x0aCan't find string terminator '"' anywhere before EOF at -e line 1.\0x0a
'
#     expected: '1:Hello World\0x0a2:HELLO World\0x0a'

#   Failed test at t\run.t line 797.

#   Failed test at t\run.t line 798.

#   Failed test at t\run.t line 800.
#                   ''
#     doesn't match '(?^s:^(?:HELLO World\n|Hello world\n){2}$)'

#   Failed test at t\run.t line 801.
#                   'Can't find string terminator '"' anywhere before EOF at -e line 1.
# Can't find string terminator '"' anywhere before EOF at -e line 1.
# '
#     doesn't match '(?^s:^(?:[12]:Hello World.*){2}$)'

#   Failed test at t\run.t line 823.

#   Failed test at t\run.t line 834.

#   Failed test at t\run.t line 842.
t\run.t .. 242/268 # Looks like you failed 11 tests of 268.
t\run.t .. Dubious, test returned 11 (wstat 2816, 0xb00)
Failed 11/268 subtests
        (less 32 skipped subtests: 225 okay)

Test Summary Report
-------------------
t\run.t (Wstat: 2816 Tests: 268 Failed: 11)
  Failed tests:  174-175, 177-180, 182-183, 198, 203, 206
  Non-zero exit status: 11
Files=1, Tests=268,  5 wallclock secs ( 0.06 usr +  0.05 sys =  0.11 CPU)
Result: FAIL
</pre>
