### PR TITLE
Improve command argument escaping on windows

### DIFF
--- a/lib/IPC/Run/Win32Helper.pm
+++ b/lib/IPC/Run/Win32Helper.pm
@@ -442,8 +442,15 @@ sub win32_spawn {
 
     my $process;
     my $cmd_line = join " ", map {
-        ( my $s = $_ ) =~ s/"/"""/g;
-        $s = qq{"$s"} if /[\"\s]|^$/;
+        my $s = $_;
+        if ($s eq "") {
+            $s = '""';
+        } elsif ($s =~ /[\s"]/) {
+            # Double-quotes will be escaped with a backslash, and any backslash
+            # that immediately precedes a double-quote will also be escaped.
+            $s =~ s/(\\*)"/$1$1\\"/g;
+            $s = '"' . $s . '"';
+        }
         $s;
     } @$cmd;
 


### PR DESCRIPTION
I ran into an issue where passing an argument with a double-quote in it didn't work on windows.

After some investigation I found this page http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx

It seems to be that using """ to escape a quote isn't the correct way to do the escaping. I'm curious in what cases was this working before as it is?

This pull request changes the command argument escaping for windows to escape double quotes with a backslash, and also any backslashes that precede a double quote with another double quote.

Let me know if there is some compatibility issue I am missing.