### PR TITLE
sync $VERSION across all files.

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -550,7 +550,7 @@ IPC::Run.  Frequently, programs alter their behavior when they detect
 that stdin, stdout, or stderr are not connected to a tty, assuming that
 they are being run in batch mode.  Whether this helps or hurts depends
 on which optimizations change.  And there's often no way of telling
-what a program does in these areas other than trial and error and,
+what a program does in these areas other than trial and error and
 occasionally, reading the source.  This includes different versions
 and implementations of the same program.
 

--- a/lib/IPC/Run/Debug.pm
+++ b/lib/IPC/Run/Debug.pm
@@ -70,7 +70,7 @@ use strict;
 use Exporter;
 use vars qw{$VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS};
 BEGIN {
-	$VERSION = '0.90';
+	$VERSION = '0.94';
 	@ISA     = qw( Exporter );
 	@EXPORT  = qw(
 		_debug

--- a/lib/IPC/Run/IO.pm
+++ b/lib/IPC/Run/IO.pm
@@ -72,7 +72,7 @@ use IPC::Run qw( Win32_MODE );
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '0.90';
+	$VERSION = '0.94';
 	if ( Win32_MODE ) {
 		eval "use IPC::Run::Win32Helper; require IPC::Run::Win32IO; 1"
 		or ( $@ && die ) or die "$!";

--- a/lib/IPC/Run/Timer.pm
+++ b/lib/IPC/Run/Timer.pm
@@ -163,7 +163,7 @@ use Symbol;
 use Exporter;
 use vars qw( $VERSION @ISA @EXPORT_OK %EXPORT_TAGS );
 BEGIN {
-	$VERSION   = '0.90';
+	$VERSION   = '0.94';
 	@ISA       = qw( Exporter );
 	@EXPORT_OK = qw(
 		check

--- a/lib/IPC/Run/Win32Helper.pm
+++ b/lib/IPC/Run/Win32Helper.pm
@@ -24,7 +24,7 @@ use Carp;
 use IO::Handle;
 use vars qw{ $VERSION @ISA @EXPORT };
 BEGIN {
-	$VERSION = '0.90';
+	$VERSION = '0.94';
 	@ISA = qw( Exporter );
 	@EXPORT = qw(
 		win32_spawn

--- a/lib/IPC/Run/Win32IO.pm
+++ b/lib/IPC/Run/Win32IO.pm
@@ -31,7 +31,7 @@ require POSIX;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '0.90';
+	$VERSION = '0.94';
 }
 
 use Socket qw( IPPROTO_TCP TCP_NODELAY );

--- a/lib/IPC/Run/Win32Pump.pm
+++ b/lib/IPC/Run/Win32Pump.pm
@@ -29,7 +29,7 @@ It parses a bunch of command line parameters from IPC::Run::Win32IO.
 use strict;
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '0.90';
+	$VERSION = '0.94';
 }
 
 use Win32API::File qw(


### PR DESCRIPTION
Sync up $VERSION across all files.  This mitigates one of the core metric fails in the IPC::Run kwalitee check.