### PR TITLE
Better sanity checks in Timer time strings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,8 +27,7 @@ TOHERE
 		## Die nicely in case some install manager cares about the canonical
 		## error message for this.  Not that I've ever seen one, but those
 		## wacky CPANPLUSers might just do something cool in this case.
-
-      		## Older perls' Socket.pm don't export IPPROTO_TCP
+		## Older perls' Socket.pm don't export IPPROTO_TCP
 		require 5.006;
 		## Most of the time it's not needed (since IPC::Run tries not to
 		## use sockets), but the user is not likely to know what the hell
@@ -37,6 +36,11 @@ TOHERE
 		## If something really odd is happening...
 		exit 1;
 	}
+}
+
+if ( $^V < version->parse('v5.8.1') ) {
+    # need Scalar::Util::looks_like_number
+	$PREREQ_PM{'Scalar::List::Utils'} = '1.10';
 }
 
 WriteMakefile(

--- a/lib/IPC/Run/Timer.pm
+++ b/lib/IPC/Run/Timer.pm
@@ -71,9 +71,9 @@ it's in.
 
 =head2 Time values
 
-All time values are in seconds.  Times may be specified as integer or
-floating point seconds, optionally preceded by puncuation-separated
-days, hours, and minutes.\
+All time values are in seconds.  Times may be any kind of perl number,
+e.g. as integer or floating point seconds, optionally preceded by
+punctuation-separated days, hours, and minutes.
 
 Examples:
 
@@ -84,6 +84,7 @@ Examples:
    1:1         1 minute, 1 second
    1:90        2 minutes, 30 seconds
    1:2:3:4.5   1 day, 2 hours, 3 minutes, 4.5 seconds
+   'inf'       the infinity perl special number (the timer never finishes)
 
 Absolute date/time strings are *not* accepted: year, month and
 day-of-month parsing is not available (patches welcome :-).
@@ -161,6 +162,7 @@ use Carp;
 use Fcntl;
 use Symbol;
 use Exporter;
+use Scalar::Util;
 use vars qw( $VERSION @ISA @EXPORT_OK %EXPORT_TAGS );
 BEGIN {
 	$VERSION   = '0.90';
@@ -202,9 +204,11 @@ sub _parse_time {
          if (scalar @f > 4) {
             croak "IPC::Run: expected <= 4 elements in time string '$_'";
          }
-         map {
-            $_ =~ /\d+/ ? $_ : croak "IPC::Run: non-numeric element '$_' in time string '$_'";
-         } @f;
+         for (@f) {
+            if (not Scalar::Util::looks_like_number($_)) {
+               croak "IPC::Run: non-numeric element '$_' in time string '$_'";
+            }
+         }
          my ( $s, $m, $h, $d ) = reverse @f;
          $val = ( (
              ( $d || 0 )   * 24

--- a/lib/IPC/Run/Timer.pm
+++ b/lib/IPC/Run/Timer.pm
@@ -194,18 +194,26 @@ my $resolution = 1;
 
 sub _parse_time {
    for ( $_[0] ) {
-      return $_ unless defined $_;
-      return $_ if /^\d*(?:\.\d*)?$/;
-
-      my @f = reverse split( /[^\d\.]+/i );
-      croak "IPC::Run: invalid time string '$_'" unless @f <= 4;
-      my ( $s, $m, $h, $d ) = @f;
-      return
-      ( (
-	         ( $d || 0 )   * 24
-	       + ( $h || 0 ) ) * 60
-	       + ( $m || 0 ) ) * 60
-               + ( $s || 0 );
+      my $val;
+      if (not defined $_) {
+         $val = $_;
+      }
+      elsif (/^\d*(?:\.\d*)?$/) {
+         $val = $_;
+      }
+      else {
+         my @f = reverse split( /[^\d\.]+/i );
+         if (scalar @f > 4) {
+            croak "IPC::Run: expected <= 4 elements in time string '$_'";
+         }
+         my ( $s, $m, $h, $d ) = @f;
+         $val = ( (
+             ( $d || 0 )   * 24
+           + ( $h || 0 ) ) * 60
+           + ( $m || 0 ) ) * 60
+           + ( $s || 0 );
+      }
+      return $val;
    }
 }
 

--- a/lib/IPC/Run/Timer.pm
+++ b/lib/IPC/Run/Timer.pm
@@ -197,16 +197,15 @@ sub _parse_time {
       my $val;
       if (not defined $_) {
          $val = $_;
-      }
-      elsif (/^\d*(?:\.\d*)?$/) {
-         $val = $_;
-      }
-      else {
-         my @f = reverse split( /[^\d\.]+/i );
+      } else {
+         my @f = split( /:/, $_, -1 );
          if (scalar @f > 4) {
             croak "IPC::Run: expected <= 4 elements in time string '$_'";
          }
-         my ( $s, $m, $h, $d ) = @f;
+         map {
+            $_ =~ /\d+/ ? $_ : croak "IPC::Run: non-numeric element '$_' in time string '$_'";
+         } @f;
+         my ( $s, $m, $h, $d ) = reverse @f;
          $val = ( (
              ( $d || 0 )   * 24
            + ( $h || 0 ) ) * 60
@@ -315,10 +314,7 @@ sub new {
 
    while ( @_ ) {
       my $arg = shift;
-      if ( $arg =~ /^(?:\d+[^\a\d]){0,3}\d*(?:\.\d*)?$/ ) {
-         $self->interval( $arg );
-      }
-      elsif ( $arg eq 'exception' ) {
+      if ( $arg eq 'exception' ) {
          $self->exception( shift );
       }
       elsif ( $arg eq 'name' ) {
@@ -328,7 +324,7 @@ sub new {
          $self->debug( shift );
       }
       else {
-         croak "IPC::Run: unexpected parameter '$arg'";
+         $self->interval( $arg );
       }
    }
 

--- a/t/timer.t
+++ b/t/timer.t
@@ -19,7 +19,7 @@ BEGIN {
 	}
 }
 
-use Test::More tests => 72;
+use Test::More tests => 73;
 use IPC::Run qw( run );
 use IPC::Run::Timer qw( :all );
 
@@ -47,6 +47,12 @@ $t->interval( "1:1:1"     );  is( $t->interval,   3661 );
 $t->interval( "1:1:1.1"   );  ok( $t->interval >  3661 );
 $t->interval( "1:1:1.1"   );  ok( $t->interval <= 3662 );
 $t->interval( "1:1:1:1"   );  is( $t->interval,  90061 );
+
+SCOPE: {
+   eval { $t->interval( "1:1:1:1:1" ) };
+   my $msg = 'IPC::Run: expected <= 4';
+   $@ =~ /$msg/ ? ok( 1 ) : is( $@, $msg );
+}
 
 $t->reset;
 $t->interval( 5 );

--- a/t/timer.t
+++ b/t/timer.t
@@ -19,7 +19,7 @@ BEGIN {
 	}
 }
 
-use Test::More tests => 76;
+use Test::More tests => 77;
 use IPC::Run qw( run );
 use IPC::Run::Timer qw( :all );
 
@@ -40,6 +40,8 @@ $t->interval(  1          );  ok( $t->interval >=    1 );
 $t->interval( 30          );  ok( $t->interval >=   30 );
 $t->interval( 30.1        );  ok( $t->interval >    30 );
 $t->interval( 30.1        );  ok( $t->interval <=   31 );
+
+$t->interval( 'inf'       );  ok( $t->interval >  1000 );
 
 $t->interval( "1:0"       );  is( $t->interval,     60 );
 $t->interval( "1:0:0"     );  is( $t->interval,   3600 );

--- a/t/timer.t
+++ b/t/timer.t
@@ -19,7 +19,7 @@ BEGIN {
 	}
 }
 
-use Test::More tests => 73;
+use Test::More tests => 76;
 use IPC::Run qw( run );
 use IPC::Run::Timer qw( :all );
 
@@ -51,6 +51,24 @@ $t->interval( "1:1:1:1"   );  is( $t->interval,  90061 );
 SCOPE: {
    eval { $t->interval( "1:1:1:1:1" ) };
    my $msg = 'IPC::Run: expected <= 4';
+   $@ =~ /$msg/ ? ok( 1 ) : is( $@, $msg );
+}
+
+SCOPE: {
+   eval { $t->interval( "foo" ) };
+   my $msg = 'IPC::Run: non-numeric';
+   $@ =~ /$msg/ ? ok( 1 ) : is( $@, $msg );
+}
+
+SCOPE: {
+   eval { $t->interval( "1foo1:9:bar:0" ) };
+   my $msg = 'IPC::Run: non-numeric';
+   $@ =~ /$msg/ ? ok( 1 ) : is( $@, $msg );
+}
+
+SCOPE: {
+   eval { $t->interval( "6:4:" ) };
+   my $msg = 'IPC::Run: non-numeric';
    $@ =~ /$msg/ ? ok( 1 ) : is( $@, $msg );
 }
 


### PR DESCRIPTION
Hi,
I have revisited the time strings error checking in IPC::Run::Timer and added some unit tests. As a result, Timer now detects malformed time strings that it did not before. It also now supports a wider range of allowable perl numbers. Specifically, the 'inf' perl number (infinity) is now supported, which makes it possible to have a timer that never stops.
Let me know if you have any questions. Cheers,
Florent