### PR TITLE
doc fix: full_result returns $?, not $? >> 8

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -3536,7 +3536,7 @@ value for a child process.
 
 To get the result of a particular child, do:
 
-   $h->full_result( 0 );  # first child's $? >> 8
+   $h->full_result( 0 );  # first child's $?
    $h->full_result( 1 );  # second child
 
 or


### PR DESCRIPTION
I did not change README and README.md --- hopefully these are autogenerated from the IPC::Run Pod.