### PR TITLE
Fix check for reaped PID in reap_nb

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -3399,7 +3399,7 @@ sub reap_nb {
                   if _debugging;
 
                 confess "waitpid returned the wrong PID: $pid instead of $kid->{PID}"
-                  unless $pid = $kid->{PID};
+                  unless $pid == $kid->{PID};
                 _debug "$kid->{PID} returned $?\n" if _debugging;
                 $kid->{RESULT} = $?;
             }


### PR DESCRIPTION
When `reap_nb` successfully reaps a child, it verifies that the PID of the
reaped process matches the known PID of the child. However, due to a
typo, it actually assigns `$kid->{PID}` to `$pid` instead of comparing them.
`$kid->{PID}` must be non-zero, so the statement modified by `unless` will
never run.

This adds the missing equals sign.