### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/t/filter.t
+++ b/t/filter.t
@@ -21,6 +21,7 @@ BEGIN {
 }
 
 use Test::More tests => 80;
+use lib '.';
 use t::lib::Test;
 use IPC::Run qw( :filters :filter_imp );
 

--- a/t/run.t
+++ b/t/run.t
@@ -40,6 +40,7 @@ select STDOUT;
 use Test::More tests => 268;
 use IPC::Run::Debug qw( _map_fds );
 use IPC::Run qw( :filters :filter_imp start );
+use lib '.';
 use t::lib::Test;
 
 # Must do this this late as plan uses localtime, and localtime on darwin opens

--- a/t/signal.t
+++ b/t/signal.t
@@ -22,6 +22,7 @@ BEGIN {
 
 use Test::More;
 use IPC::Run qw( :filters :filter_imp start run );
+use lib '.';
 use t::lib::Test;
 
 BEGIN {


### PR DESCRIPTION
In perl-5.26.0, '.' will no longer be found by default in @INC.  This patch
adjusts tests to accommodate that.

For:  https://rt.cpan.org/Ticket/Display.html?id=120406