### PR TITLE
Fix variable name in synopsis

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -15,10 +15,10 @@ IPC::Run - system() and background procs w/ piping, redirs, ptys (Unix, Win32)
    ## Using run() instead of system():
       use IPC::Run qw( run timeout );
 
-      run \@cmd, \$in, \$out, \$err, timeout( 10 ) or die "cat: $?"
+      run \@cat, \$in, \$out, \$err, timeout( 10 ) or die "cat: $?"
 
       # Can do I/O to sub refs and filenames, too:
-      run \@cmd, '<', "in.txt", \&out, \&err or die "cat: $?"
+      run \@cat, '<', "in.txt", \&out, \&err or die "cat: $?"
       run \@cat, '<', "in.txt", '>>', "out.txt", '2>>', "err.txt";
 
 


### PR DESCRIPTION
Consistently use `@cat`, the variable defined at the start containing the cat command. Some example lines used `@cmd`, which isn't defined anywhere.

It's been like that since at least be936f2ebab1, the initial import from Cpan, over a decade ago.

Fixes #47.