### PR TITLE
Duplicate the fd even if it's the same in the child

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension IPC::Run
 
+ - GitHub #99 - Fix using fd in child process when it happens to be the same
+   number in the child as it was in the parent.
+
 0.96 Fri May 12 2017
  - Update bug tracker to https://github.com/toddr/IPC-Run/issues
 

--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -2566,6 +2566,10 @@ sub _do_kid_and_exit {
                 unless ( $_->{TFD} == $_->{KFD} ) {
                     $self->_dup2_gently( $kid->{OPS}, $_->{TFD}, $_->{KFD} );
                     push @lazy_close, $_->{TFD};
+                } else {
+                    my $fd = _dup($_->{TFD});
+                    $self->_dup2_gently( $kid->{OPS}, $fd, $_->{KFD} );
+                    _close($fd);
                 }
             }
             elsif ( $_->{TYPE} eq 'dup' ) {

--- a/t/parent_and_child_fds_match.t
+++ b/t/parent_and_child_fds_match.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+#
+# Test a child process can use the fd if it happens to be the same number as it
+# was in the parent.
+
+use strict;
+use warnings;
+
+use Data::Dumper qw( Dumper );
+use File::Temp qw( tempfile );
+use IO::Handle ();
+use IPC::Run ();
+use Test::More;
+
+if (@ARGV > 0 && $ARGV[0] eq 'child') {
+    exit(child());
+}
+
+exit(parent());
+
+sub child {
+    my $fh = IO::Handle->new_from_fd(3, '+<');
+    die "new_from_fd(): $!" unless defined $fh;
+    return 0;
+}
+
+sub parent {
+    # This is fd 3 since we have 0, 1, 2 taken by stdin, stdout, and stderr.
+    my $fh = tempfile();
+    ok($fh, 'opened file');
+
+    my @command = ($0, 'child');
+
+    my $stdout = sub { note_output("stdout", $_); return; };
+    my $stderr = sub { note_output("stderr", $_); return; };
+
+    my $harness = IPC::Run::start(
+        \@command,
+        \undef,  # fd 0
+        $stdout, # fd 1
+        $stderr, # fd 2
+        $fh,     # fd 3
+    );
+
+    ok($harness, 'started process');
+
+    ok($harness->finish, 'child process exited with success status');
+
+    done_testing();
+    return 0;
+}
+
+sub note_output {
+    my ($prefix, $rest) = @_;
+    if (ref $rest) {
+        note("$prefix: " . Dumper($rest));
+        return;
+    }
+    note("$prefix: $rest");
+    return;
+}


### PR DESCRIPTION
This is to fix an issue where we sometimes can pass an fd to our child
and sometimes not. If the source fd in the parent happens to be the same
as the fd what it would be in the child, we previously did not dupe it.
Due to FD_CLOEXEC, this means the child would not be able to use the fd.

This could happen if your program opened a single fd you wanted to pass
to the child. This fd would then likely have fd 3. Then consider if you
want to pass it as fd 3 to the child. e.g., `start(\@cmd, \undef,
$stdout, $stderr, $yourfd)`.

Instead, we now duplicate it so it will be usable in the child.