### PR TITLE
Prevent Not a GLOB reference in close_terminal by untieing before close

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -2462,6 +2462,11 @@ STDIN, STDOUT, or STDERR to be guaranteed effective.
 sub close_terminal {
     ## Cast of the bonds of a controlling terminal
 
+    # Just in case the parent (I'm talking to you FCGI) had these tied.
+    untie *STDIN;
+    untie *STDOUT;
+    untie *STDERR;
+
     POSIX::setsid() || croak "POSIX::setsid() failed";
     _debug "closing stdin, out, err"
       if _debugging_details;


### PR DESCRIPTION
Addresses https://github.com/toddr/IPC-Run/issues/53