### PR TITLE
child fd inadvertently closed if TFDs need to be moved

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -1256,7 +1256,7 @@ sub _dup {
     croak "$!: dup( $_[0] )" unless defined $r;
     $r = 0 if $r eq '0 but true';
     _debug "dup( $_[0] ) = $r" if _debugging_details;
-    $fds{$r} = 1;
+    $fds{$r} = {};
     return $r;
 }
 
@@ -1266,7 +1266,7 @@ sub _dup2_rudely {
     croak "$!: dup2( $_[0], $_[1] )" unless defined $r;
     $r = 0 if $r eq '0 but true';
     _debug "dup2( $_[0], $_[1] ) = $r" if _debugging_details;
-    $fds{$r} = 1;
+    $fds{$r} = {};
     return $r;
 }
 
@@ -1309,7 +1309,7 @@ sub _sysopen {
     croak "$!: open( $_[0], ", sprintf( "0x%03x", $_[1] ), " )" unless defined $r;
     _debug "open( $_[0], ", sprintf( "0x%03x", $_[1] ), " ) = $r"
       if _debugging_data;
-    $fds{$r} = 1;
+    $fds{$r} = {};
     return $r;
 }
 
@@ -1320,7 +1320,7 @@ sub _pipe {
     my ( $r, $w ) = POSIX::pipe;
     croak "$!: pipe()" unless defined $r;
     _debug "pipe() = ( $r, $w ) " if _debugging_details;
-    $fds{$r} = $fds{$w} = 1;
+    @fds{$r, $w} = ( {}, {} );
     return ( $r, $w );
 }
 
@@ -1354,7 +1354,7 @@ sub _pty {
     $pty->blocking(0) or croak "$!: pty->blocking ( 0 )";
     _debug "pty() = ( ", $pty->fileno, ", ", $pty->slave->fileno, " )"
       if _debugging_details;
-    $fds{ $pty->fileno } = $fds{ $pty->slave->fileno } = 1;
+    @fds{ $pty->fileno, $pty->slave->fileno } = ( {}, {} );
     return $pty;
 }
 
@@ -2468,9 +2468,10 @@ sub _dup2_gently {
         next unless defined $_->{TFD};
         $_->{TFD} = _dup( $_->{TFD} ) if $_->{TFD} == $fd2;
     }
-    $self->{DEBUG_FD} = _dup $self->{DEBUG_FD}
-      if defined $self->{DEBUG_FD} && $self->{DEBUG_FD} == $fd2;
-
+    if ( defined $self->{DEBUG_FD} && $self->{DEBUG_FD} == $fd2 ) {
+        $self->{DEBUG_FD} = _dup $self->{DEBUG_FD};
+        $fds{$self->{DEBUG_FD}}{needed} = 1;
+    }
     _dup2_rudely( $fd1, $fd2 );
 }
 
@@ -2530,39 +2531,41 @@ sub _do_kid_and_exit {
         ## close parent FD's first so they're out of the way.
         ## Don't close STDIN, STDOUT, STDERR: they should be inherited or
         ## overwritten below.
-        my @needed = $self->{noinherit} ? () : ( 1, 1, 1 );
-        $needed[ $self->{SYNC_WRITER_FD} ] = 1;
-        $needed[ $self->{DEBUG_FD} ] = 1 if defined $self->{DEBUG_FD};
+        do { $_->{needed} = 1 for @fds{0..2} }
+           unless $self->{noinherit};
 
-        for ( @{ $kid->{OPS} } ) {
-            $needed[ $_->{TFD} ] = 1 if defined $_->{TFD};
-        }
+        $fds{$self->{SYNC_WRITER_FD}}{needed} = 1;
+        $fds{$self->{DEBUG_FD}}{needed} = 1 if defined $self->{DEBUG_FD};
+
+        $fds{$_->{TFD}}{needed} = 1
+           foreach grep { defined $_->{TFD} } @{$kid->{OPS} };
+
 
         ## TODO: use the forthcoming IO::Pty to close the terminal and
         ## make the first pty for this child the controlling terminal.
         ## This will also make it so that pty-laden kids don't cause
         ## other kids to lose stdin/stdout/stderr.
-        my @closed;
+
         if ( %{ $self->{PTYS} } ) {
             ## Clean up the parent's fds.
             for ( keys %{ $self->{PTYS} } ) {
                 _debug "Cleaning up parent's ptty '$_'" if _debugging_details;
                 $self->{PTYS}->{$_}->make_slave_controlling_terminal;
                 my $slave = $self->{PTYS}->{$_}->slave;
-                $closed[ $self->{PTYS}->{$_}->fileno ] = 1;
+ 	        delete $fds{$self->{PTYS}->{$_}->fileno};
                 close $self->{PTYS}->{$_};
                 $self->{PTYS}->{$_} = $slave;
             }
 
             close_terminal;
-            $closed[$_] = 1 for ( 0 .. 2 );
+            delete @fds{0..2};
         }
 
         for my $sibling ( @{ $self->{KIDS} } ) {
             for ( @{ $sibling->{OPS} } ) {
                 if ( $_->{TYPE} =~ /^.pty.$/ ) {
                     $_->{TFD} = $self->{PTYS}->{ $_->{PTY_ID} }->fileno;
-                    $needed[ $_->{TFD} ] = 1;
+                    $fds{$_->{TFD}}{needed} = 1;
                 }
 
                 #	    for ( $_->{FD}, ( $sibling != $kid ? $_->{TFD} : () ) ) {
@@ -2578,21 +2581,18 @@ sub _do_kid_and_exit {
         ## This is crude: we have no way of keeping track of browsing all open
         ## fds, so we scan to a fairly high fd.
         _debug "open fds: ", join " ", keys %fds if _debugging_details;
-        for ( keys %fds ) {
-            if ( !$closed[$_] && !$needed[$_] ) {
-                _close($_);
-                $closed[$_] = 1;
-            }
-        }
 
-        ## Lazy closing is so the same fd (ie the same TFD value) can be dup2'ed on
-        ## several times.
-        my @lazy_close;
+        _close( $_ ) foreach grep { ! $fds{$_}{needed} } keys %fds;
+
         for ( @{ $kid->{OPS} } ) {
             if ( defined $_->{TFD} ) {
+
+                # we're always creating KFD
+                $fds{$_->{KFD}}{needed} = 1;
+
                 unless ( $_->{TFD} == $_->{KFD} ) {
                     $self->_dup2_gently( $kid->{OPS}, $_->{TFD}, $_->{KFD} );
-                    push @lazy_close, $_->{TFD};
+                    $fds{$_->{TFD}}{lazy_close} = 1;
                 } else {
                     my $fd = _dup($_->{TFD});
                     $self->_dup2_gently( $kid->{OPS}, $fd, $_->{KFD} );
@@ -2602,12 +2602,12 @@ sub _do_kid_and_exit {
             elsif ( $_->{TYPE} eq 'dup' ) {
                 $self->_dup2_gently( $kid->{OPS}, $_->{KFD1}, $_->{KFD2} )
                   unless $_->{KFD1} == $_->{KFD2};
+                $fds{$_->{KFD2}}{needed} = 1;
             }
             elsif ( $_->{TYPE} eq 'close' ) {
                 for ( $_->{KFD} ) {
-                    if ( !$closed[$_] ) {
+                    if ( $fds{$_} ) {
                         _close($_);
-                        $closed[$_] = 1;
                         $_ = undef;
                     }
                 }
@@ -2617,12 +2617,7 @@ sub _do_kid_and_exit {
             }
         }
 
-        for (@lazy_close) {
-            unless ( $closed[$_] ) {
-                _close($_);
-                $closed[$_] = 1;
-            }
-        }
+        _close( $_ ) foreach grep { $fds{$_}{lazy_close} } keys %fds;
 
         if ( ref $kid->{VAL} ne 'CODE' ) {
             open $s1, ">&=$self->{SYNC_WRITER_FD}"

--- a/t/child_fd_inadvertently_closed.t
+++ b/t/child_fd_inadvertently_closed.t
@@ -1,0 +1,64 @@
+#! perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use IPC::Run 'run';
+
+use File::Temp;
+use IO::Handle;
+
+use POSIX ();
+
+# trigger IPC::Run bug where parent has $fd open
+# and child needs $fd & $fd+1
+
+my $error;
+
+sub parent {
+
+    # dup stderr so we get some fd
+    my $xfd = POSIX::dup( 2 );
+    die $! if $xfd == -1;
+
+    my @fds = ( $xfd, $xfd + 1 );
+
+    # create input files to be attached to the fds
+    my @tmp;
+    @tmp[@fds] = map {
+        my $tmp = File::Temp->new;
+        $tmp->print( $_ );
+        $tmp->close;
+        $tmp
+    } @fds;
+
+
+    # child reads from fds and make sure that
+    # it can open them and that they're attached
+    # to the files it expects.
+    my $child = sub {
+
+        for my $fd ( @fds ) {
+
+            my $io = IO::Handle->new_from_fd( $fd, '<' )
+              or print( STDERR ( "error fdopening $fd\n" ) ), next;
+
+            my $input = $io->getline;
+            print STDERR "expected >$fd<.  got >$input<\n"
+              unless $fd eq $input;
+
+        }
+
+
+    };
+
+    run $child,(  map { $_ . '<', $tmp[$_]->filename } @fds, ), '2>', \$error;
+
+    POSIX::close $xfd;
+}
+
+parent;
+is ( $error, '', "child fd not closed" )
+  or note $error;


### PR DESCRIPTION
If the parent process has an open fd which is the first in a sequence
of fds that will be used by the child process, the child fd accounting
code loses track of which fds to close, and ends up closing one needed
by the eventual sub-process.

Assume that the parent has fd=3 open. The child requires fd=3 & fd=4.
The parent opens fds 4 and 5 to handle the child's fds, as
it can't perform a direct map because of fd=3 being open.

The parent creates OPS entries with

OPS[0]: { TFD => 4, KFD => 3 }
OPS[1]: { TFD => 5, KFD => 4 }

In the child, fd=3 is closed as it is not needed.

The child handles the moving of fds in _do_kid_and_exit:

   2581   ## Lazy closing is so the same fd (ie the same TFD value) can be dup2'ed on
   2582   ## several times.
   2583   my @lazy_close;
   2584   for ( @{ $kid->{OPS} } ) {
   2585       if ( defined $_->{TFD} ) {
   2586           unless ( $_->{TFD} == $_->{KFD} ) {
   2587               $self->_dup2_gently( $kid->{OPS}, $_->{TFD}, $_->{KFD} );
   2588               push @lazy_close, $_->{TFD};
   2589           }
   2590       }
   ....
   2607   }

When servicing OPS[0], _dup2_gently dups fd=4 to fd=3 and line 2604
records fd=4 as needing to be closed.

When servicing OPS[1], _dup2_gently notices that OPS[0]{TFD} conflicts
with OPS[1]{KFD} and dups OPS[0]{TFD} elsewhere. It then dups fd=5
to fd=4 and line 2604 records fd=5 as needing to be closed.

At this point the fds marked in @lazy_close are closed:

   2609   for (@lazy_close) {
   2610       unless ( $closed[$_] ) {
   2611           _close($_);
   2612           $closed[$_] = 1;
   2613       }
   2614   }

and fd=4 gets closed even though it is needed by OPS[1].

So that's one bug. The other bug is that @lazy_close doesn't know
that OPS[0]{TFD} got moved (that was done in _dup2_gently), so that
fd does not get closed.

There's a quick and dirty work-around to fix the first problem, but I
think there is a more substantial problem at work here. There are
multiple different places that information about fds are kept:

* @fds
* @needed
* @closed
* @lazy_close

This can be simplified. The following notes are for the child process
only; I haven't analyzed the code for the parent process. This commit
doesn't affect the parent process.

* @fds is the most important data structure; it records the known open
  fds. It is already consistently managed by the _close, _dup, and
  _dup2_rudely routines.

* @needed is useful, but because it is separate from @fds, it can get
  out of sync. it is also local to a single function
  (_do_kid_and_exit) when it needs to be accessible elsewhere
  (e.g. _dup2_gently)

* There's no need for @closed; if the fd is not in @fds, it's not open.

* @lazy_close means that an fd is not needed, but don't delete it
  right away. There are two aspects to this. First, there's already
  the @needed array, so this duplicates that functionality.  Second,
  @lazy_close is never used as a guard to *prevent* closing an fd. So
  it really has no use. Simply recording the fd in @needed as not
  being needed is sufficient.

This commit does a couple of things.

* It uses @fds as the *only* repository of information about fds, so
  all information is centralized. @fds is now an array of hashes.

* @needed is replaced by the {needed} attribute in an @fds element,
  e.g. fds[0]{needed} = 1.

* Since @fds is the canonical list of fds and is managed correctly,
  @closed is not needed.

* @lazy_close is also no longer needed; the {needed} attribute for an
  fd is set to 0 so that it will be closed during the next sweep.

* the code is more explicit about specifying which fds are needed or
  not. In particular, it explicitly marks KFDs as needed after they
  are created. This prevents inadvertent closing of KFD's whose fds
  were previously TFDs. When a TFD fd is moved by _dup2_gently the new
  entry in @fds defaults to {needed} = 0, and it will get cleaned up
  during the next fd closing sweep.