### PR TITLE
fix usage of setsid

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -2493,7 +2493,7 @@ sub close_terminal {
     untie *STDOUT;
     untie *STDERR;
 
-    POSIX::setsid() || croak "POSIX::setsid() failed";
+    POSIX::setsid() == -1 and croak "POSIX::setsid() failed";
     _debug "closing stdin, out, err"
       if _debugging_details;
     close STDIN;


### PR DESCRIPTION
POSIX::setsid returns -1, not undef on failure:
```
❯ perl -MPOSIX -le 'my $ret = POSIX::setsid; print "$ret: $!"'
-1: Operation not permitted
```