### PR TITLE
kill_kill: Immediately KILL the child process as documented for Win32.

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -1589,7 +1589,14 @@ sub kill_kill {
       join " ", keys %options
       if keys %options;
 
-    $self->signal("TERM");
+    if (Win32_MODE) {
+	# immediate brutal death for Win32
+	# TERM has unfortunate side-effects
+	$self->signal("KILL")
+    }
+    else {
+	$self->signal("TERM");
+    }
 
     my $quitting_time = time + $grace;
     my $delay         = 0.01;


### PR DESCRIPTION
The TERM signal ends up as a call to GenerateConsoleCtrlEvent()
which sends the signal to the entire process group, with
confusing results.

The other option is to follow what the core does for system(1, ...) and create a new process group for each new child.

Note that a few other tests fail, but that doesn't appear to be due to this change.