### PR TITLE
skip test on NetBSD too

### DIFF
--- a/t/pty.t
+++ b/t/pty.t
@@ -103,7 +103,7 @@ my $text = "hello world\n";
 
 ## Older Perls can't ok( a, qr// ), so I manually do that here.
 my $exp;
-my $platform_skip = $^O =~ /(?:dragonfly|aix|freebsd|openbsd|darwin)/ ? "$^O deadlocks on this test" : "";
+my $platform_skip = $^O =~ /(?:dragonfly|aix|freebsd|openbsd|netbsd|darwin)/ ? "$^O deadlocks on this test" : "";
 
 ##
 ## stdin only


### PR DESCRIPTION
NetBSD hangs too.  I don't pretend to understand all of what this test is doing and why it should be skipped on *BSD, but if all of the other popular *BSDs should be skipped then NetBSD should too.