### PR TITLE
Fix bitrot in "windows" workflow.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,10 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - name: Set up Perl
-        run: |
-          choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
       - name: perl -V
         run: perl -V
       - name: Makefile.PL


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands
withdrew support for `##[add-path]`.  The runner image already has
strawberryperl in its path, so just remove step `Set up Perl`.

At first, I just translated the old code to comply with [newer guidance](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path).
That yielded:

```
choco install strawberryperl
"C:\strawberry\perl\bin" >>$Env:GITHUB_PATH
"C:\strawberry\perl\site\bin" >>$Env:GITHUB_PATH
"C:\strawberry\c\bin" >>$Env:GITHUB_PATH
```

However, I then found strawberryperl [installed by default](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md).  I almost kept
the step in the interest of future proofing, but it's by far the slowest part
of the workflow.