### PR TITLE
Reproducing installation failure on windows strawberry perl

### DIFF
--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -23,14 +23,7 @@ jobs:
     - name: Check perl version
       run: perl -v
 
-    - name: Install Module
+    - name: Uninstall/Install Module
       run: |
-        cpan
-        look IPC::Run
-        perl Makefile.PL
-        dmake
-        dmake test
-        dmake install
-        
-        
-        
+        cpanm --uninstall IPC::Run
+        cpanm IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -23,6 +23,4 @@ jobs:
           distribution: strawberry
       - run: perl -V
       - name: Uninstall Module
-        run: curl https://cpanmin.us | perl - --uninstall IPC::Run
-      - name : Install Module
-        run: cpan install IPC::Run
+        run: curl https://cpanmin.us | perl - --verbose --reinstall IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -23,4 +23,4 @@ jobs:
           distribution: strawberry
       - run: perl -V
       - name: Uninstall/Install Module
-        run: curl https://cpanmin.us
+        run: curl https://cpanmin.us | perl - --reinstall IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -1,0 +1,28 @@
+name: Windows_Installation
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Install and setup Perl
+      run: |
+          choco install strawberryperl
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" >> $GITHUB_PATH
+    
+    - name: Check perl version
+      run: perl -v
+
+    - name: Install Module
+      run: |
+        cpanm IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -1,7 +1,5 @@
 name: Windows_Installation
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches:
@@ -22,5 +20,5 @@ jobs:
           perl-version: '5.30'
           distribution: strawberry
       - run: perl -V
-      - name: Uninstall Module
+      - name: Uninstall and Install Module
         run: curl https://cpanmin.us | perl - --verbose --reinstall IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -15,15 +15,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: Install and setup Perl
-      run: |
-          choco install strawberryperl
-          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" >> $GITHUB_PATH
-    
-    - name: Check perl version
-      run: perl -v
-
-    - name: Uninstall/Install Module
-      run: |
-        cpanm --uninstall IPC::Run
-        cpanm IPC::Run
+      - uses: actions/checkout@v2
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.30'
+          distribution: strawberry
+      - run: perl -V
+      - name: Uninstall/Install Module
+        run: |
+          cpanm --uninstall IPC::Run
+          cpanm IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -23,6 +23,4 @@ jobs:
           distribution: strawberry
       - run: perl -V
       - name: Uninstall/Install Module
-        run: |
-          cpanm --uninstall IPC::Run
-          cpanm IPC::Run
+        run: curl https://cpanmin.us | Select-Object -ExpandProperty Content | perl - --reinstall IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -25,4 +25,12 @@ jobs:
 
     - name: Install Module
       run: |
-        cpanm IPC::Run
+        cpan
+        look IPC::Run
+        perl Makefile.PL
+        dmake
+        dmake test
+        dmake install
+        
+        
+        

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -22,5 +22,7 @@ jobs:
           perl-version: '5.30'
           distribution: strawberry
       - run: perl -V
-      - name: Uninstall/Install Module
-        run: curl https://cpanmin.us | perl - --reinstall IPC::Run
+      - name: Uninstall Module
+        run: curl https://cpanmin.us | perl - --uninstall IPC::Run
+      - name : Install Module
+        run: cpan install IPC::Run

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -23,4 +23,4 @@ jobs:
           distribution: strawberry
       - run: perl -V
       - name: Uninstall/Install Module
-        run: curl https://cpanmin.us | Select-Object -ExpandProperty Content | perl - --reinstall IPC::Run
+        run: curl https://cpanmin.us

--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up perl
         uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: '5.30'
+          perl-version: '5.32'
           distribution: strawberry
       - run: perl -V
       - name: Uninstall and Install Module


### PR DESCRIPTION
This github workflow will help in reproducing the issue - https://github.com/toddr/IPC-Run/issues/138
Since IPC::Run comes with Strawberry Perl installation, in the workflow we are uninstalling it and installing it again.
The result of the run is at - https://github.com/rai-gaurav/IPC-Run/runs/2247420022?check_suite_focus=true