### PR TITLE
allow win32_newlines.t to actually run

### DIFF
--- a/t/win32_newlines.t
+++ b/t/win32_newlines.t
@@ -27,7 +27,7 @@ use Test::More;
 use IPC::Run 'run';
 
 plan skip_all => 'Skipping on Win32' if $ENV{GITHUB_WINDOWS_TESTING};
-plan skip_all => 'Skipping when not on Win32' unless $^O eq 'Win32';
+plan skip_all => 'Skipping when not on Win32' unless $^O eq 'MSWin32';
 plan tests => 10;
 
 $ENV{IPC_SUB_PROCESS} = 1;


### PR DESCRIPTION
While working on another test i found that this one had a bungled OS check and thus hadn't been running for a while. This PR simply reactivates it. Looks like it fails some tests.

@nmisch and @haarg might wanna have a look at this.

```
d:\cpan\IPC-Run>perl t\win32_newlines.t
1..10
ok 1 - "ab" - child got clean input
ok 2 - "ab" - parent received clean child output
not ok 3 - "\n" - child got clean input
#   Failed test '"\n" - child got clean input'
#   at t\win32_newlines.t line 42.
#          got: '"\r\n"'
#     expected: '"\n"'
ok 4 - "\n" - parent received clean child output
ok 5 - "\r" - child got clean input
ok 6 - "\r" - parent received clean child output
ok 7 - "\r\n" - child got clean input
not ok 8 - "\r\n" - parent received clean child output
#   Failed test '"\r\n" - parent received clean child output'
#   at t\win32_newlines.t line 42.
#          got: '"\n"'
#     expected: '"\r\n"'
not ok 9 - "\n\r" - child got clean input
#   Failed test '"\n\r" - child got clean input'
#   at t\win32_newlines.t line 42.
#          got: '"\r\n\r"'
#     expected: '"\n\r"'
ok 10 - "\n\r" - parent received clean child output
# Looks like you failed 3 tests of 10.
```