### PR TITLE
Disable new Windows_Installation workflow.

### DIFF
--- a/.github/workflows/windows_installation.yml
+++ b/.github/workflows/windows_installation.yml
@@ -1,12 +1,10 @@
 name: Windows_Installation
 
 on:
-  push:
-    branches:
-      - '*'
-    tags-ignore:
-      - '*'
-  pull_request:
+  # Manual runs only.  This test uses the CPAN version of IPC::Run, not Perl
+  # code at the current commit.  This test would fail even for a commit that,
+  # once released, would lead to this test passing.
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
For rationale, see comments inside the commit and https://github.com/toddr/IPC-Run/pull/145#issuecomment-852998772.

This makes the test manual-only.  I considered using
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
to run it monthly.  However, "Notifications for scheduled workflows are sent
to the user who last modified the cron syntax in the workflow file."

I'm submitting this in hopes of unblocking the pull requests that got reviews
in mid 2021 and have been waiting for someone having repository write access.