### PR TITLE
On Windows, avoid hang under IPCRUNDEBUG.

### DIFF
--- a/lib/IPC/Run/Win32IO.pm
+++ b/lib/IPC/Run/Win32IO.pm
@@ -74,7 +74,6 @@ use Win32API::File qw(
   SetHandleInformation
   SetFilePointer
   HANDLE_FLAG_INHERIT
-  INVALID_HANDLE_VALUE
 
   createFile
   WriteFile
@@ -100,7 +99,6 @@ BEGIN {
         IPPROTO_TCP,
         TCP_NODELAY,
         HANDLE_FLAG_INHERIT,
-        INVALID_HANDLE_VALUE,
     );
 }
 

--- a/t/win32_compile.t
+++ b/t/win32_compile.t
@@ -65,7 +65,6 @@ BEGIN {
       SetFilePointer
 
       HANDLE_FLAG_INHERIT
-      INVALID_HANDLE_VALUE
 
       createFile
       WriteFile


### PR DESCRIPTION
In #156, I wrote:

> For anyone experimenting with this, beware of heisenbugs when using
> IPCRUNDEBUG. The POSIX::close() calls in _map_fds can hang the same way. I
> will propose a fix for that separately.

Here's that fix.  The POSIX ways of testing whether a FD is open don't work on
for Perl on Windows, so I used Win32API::File::FdGetOsFHandle().  That turned
into a bit of a yak shave, because our existing FdGetOsFHandle() calls don't
detect failure on 64-bit Windows.  The first commit of this PR fixes the
existing calls, and the second commit fixes $SUBJECT.