### PR TITLE
t/run_stdin-callback-return-array.t: run Perl, not echo.exe.

### DIFF
--- a/t/run_stdin-callback-return-array.t
+++ b/t/run_stdin-callback-return-array.t
@@ -10,7 +10,7 @@ use Test::More tests => 9;
 
 my @cmd = ("true");
 if ($^O eq 'MSWin32') {
-  @cmd = ('cmd','/C','echo','y');
+  @cmd = ( $^X, '-e', 'exit 0' );
 }
 our ( $i, @i );
 my ( $in, @in );


### PR DESCRIPTION
This test calls cmd.exe, a program that departs from standard command line
parsing rules.  Commit fbd6d18 adopted Win32::ShellQuote, which eagerly adds
double quotes.  Those quotes have no effect on programs exhibiting standard
command line parsing rules, but they do alter the meaning of this test's
cmd.exe invocations.

Fix this by calling `$^X`, like most tests do.  An alternative to this would
be to undo the adoption of Win32::ShellQuote and return to adding only
necessary quotes, like released IPC::Run versions do.  That would reduce the
need for users to change their applications as part of adopting the next
IPC::Run release.  The original version of #143 worked that way, but I adopted
Win32::ShellQuote in response to multiple reviewer comments.  If the
compatibility break seen here change's anyone's opinion, let me know.