### PR TITLE
Update Changelog for changes since version 20200505.0.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,13 +1,14 @@
 Revision history for Perl extension IPC::Run
 
 20220801.0 Mon Aug 1 2022
- - #140 - skip io/pty.t test on NetBSD too
+ If your applications rely on portability to Windows, see new documentation
+ sections "argument-passing rules are program-specific" and "batch files".  This
+ release fixes bugs in runs of Windows programs that use standard command line
+ parsing rules.  Runs of non-standard programs may require changes.  Notable
+ non-standard programs include cmd.exe, cscript.exe, and Cygwin programs.
+ - #140 - skip t/pty.t test on NetBSD too
  - Add strict/warnings
- - #144 - Fix bitrot in github actions "windows" workflow.
  - #142 - Follow Windows argument quoting rules
- - #151 - change "when it is release." -> "when it is released." in the pod text.
- - #145 - Reproducing installation failure on windows strawberry perl in github workflow
- - #153 - Disable new Windows_Installation workflow.
  - #146 - allow win32_newlines.t to actually run
  - #150 - Make t/pty.t test pass on OpenBSD.
  - #148 - Support Win32 commands having nonstandard command line parsing rules
@@ -17,9 +18,7 @@ Revision history for Perl extension IPC::Run
  - #156 - On Windows, avoid hang when closing read end of pipe.
  - #155 - Ignore known test failure on msys. - t/windows_search_path.t
  - Avoid warning with IPCRUNDEBUG, in Windows spawned children.
- - Add "workflow_dispatch" to each GitHub workflow.
  - Use $^X, not 'perl', in tests.
- - Correct autovivification error revealed by t/pump.t.
  - Thanks to the New active developer: Noah Misch!
 
 20200505.0 Tue May 5 2020


### PR DESCRIPTION
Add a paragraph about applications needing changes.  Remove some changes
that users won't need to read about (typo, GitHub Actions, changes that
merely fix other changes since last release).