### PR TITLE
Fix t/readonly.t on Windows; run it in CI.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
         uses: perl-actions/install-with-cpm@v1.3
         with:
           cpanfile: "cpanfile"
-          args: "--configure-timeout=600"
+          args: "--configure-timeout=600 --with-recommends --with-suggests"
           sudo: false
       - run: perl Makefile.PL
       - run: make test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,8 @@ jobs:
         uses: perl-actions/install-with-cpm@v1.3
         with:
           cpanfile: "cpanfile"
-          args: "--configure-timeout=600"  # IO-Tty-1.16 exceeded 60s default
+          # IO-Tty-1.16 exceeded 60s default
+          args: "--configure-timeout=600 --with-recommends --with-suggests"
           sudo: false
       - name: Makefile.PL
         run: perl Makefile.PL

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: actions/checkout@master
       - name: perl -V
         run: perl -V
+      - name: uses install-with-cpm
+        uses: perl-actions/install-with-cpm@v1.3
+        with:
+          cpanfile: "cpanfile"
+          args: "--configure-timeout=600 --with-recommends --with-suggests"
+          sudo: false
       - name: Makefile.PL
         run: perl Makefile.PL
       - name: make test

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,22 @@
-requires 'IO::Pty'  => 0;
-requires 'Readonly' => 0;
+# The cpanfile specification does not explicitly allow testing $^O or $].  cpanm
+# tolerates this, but other cpanfile consumers might not.
+if ( $^O ne 'MSWin32' ) {
+    requires 'IO::Pty', '1.08';    # not entirely required; see Makefile.PL
+}
+else {
+    requires 'Win32',          '0.27';
+    requires 'Win32::Process', '0.14';
+    requires 'Win32::ShellQuote';
+    requires 'Win32API::File', '0.0901';
+    if ( $] >= 5.021006 ) {
+        requires 'Win32API::File', '0.1203';
+    }
+}
+on 'test' => sub {
+    requires 'Test::More', '0.47';
+    recommends 'Readonly';
+};
 on 'develop' => sub {
-    requires 'Readonly';
     requires 'Test::Pod::Coverage';
     requires 'Pod::Simple';
     requires 'Test::Pod';

--- a/t/readonly.t
+++ b/t/readonly.t
@@ -35,7 +35,7 @@ sub run_echo {
     #   my @args = ( '/bin/echo', $value );
     my @args = ( '/bin/echo', 'hello' );
     if ($^O eq 'MSWin32') {
-      @args = ('cmd','/C','echo','Hello');
+        @args = ( $^X, '-e', 'print "hello\n"' );
     }
 
     my $t = "test case '$value': '@args'";


### PR DESCRIPTION
This fixes the new t/readonly.t failure from
https://github.com/toddr/IPC-Run/issues/138#issuecomment-1207437027.  CI
would not have caught this, for the same reason it didn't catch the need
for commit 6e2d0c0be17235c247e4f9dc270b08ca210fd5a2.  Still, running the
test in CI confirms this fix doesn't break the test in a different way.
It does slow the windows workflow runs by ~15s.  Feel free to argue
that's not worth it; I'm ambivalent.

To install modules the same way non-windows CI workflows do, I used $^O
and $] conditionals in cpanfile.  The cpanfile specification is silent
about such conditionals.  cpanm is tolerating this, and I see someone
else doing it in https://github.com/beyondgrep/ack3/blob/dev/cpanfile.