### PR TITLE
Normalize shebangs to /usr/bin/perl

### DIFF
--- a/eg/abuse/blocking_debug_with_sub_coprocess
+++ b/eg/abuse/blocking_debug_with_sub_coprocess
@@ -1,4 +1,4 @@
-#!/opt/i386-linux/perl/bin/perl -w
+#!/usr/bin/perl -w
 
 ## Submitted by Blair Zajac <blair@orcaware.com>
 

--- a/eg/abuse/timers
+++ b/eg/abuse/timers
@@ -1,4 +1,4 @@
-#!/usr/local/lib/perl -w
+#!/usr/bin/perl -w
 
 use strict;
 use IPC::Run qw( :all );

--- a/eg/run_daemon
+++ b/eg/run_daemon
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl -w
 
 ## An example of how to daemonize.  See the IPC::Run LIMITATIONS section for
 ## some reasons why this can be a bit dangerous.


### PR DESCRIPTION
Unless there is a need for the special shebangs, they
should be all pointing to the standard location.

We have a patch for this module in openSUSE:
https://build.opensuse.org/package/show/devel:languages:perl/perl-IPC-Run

Since I thought there might be no reason for having those special shebangs, I decided to create this PR, so maybe we can get rid of our patch :)