### PR TITLE
Handle reference to undefined array in IPC::Run::run()

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -1803,6 +1803,8 @@ sub harness {
                     croak "Process control symbol ('|', '&') missing" if $cur_kid;
                     croak "Can't spawn a subroutine on Win32"
                       if Win32_MODE && ref eq "CODE";
+                    croak "Can't run undefined command. Did you pass a reference to an undefined array?"
+                      if !defined($_->[0]) && ref eq 'ARRAY';
                     $cur_kid = {
                         TYPE   => 'cmd',
                         VAL    => $_,

--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -1161,6 +1161,9 @@ my %cmd_cache;
 
 sub _search_path {
     my ($cmd_name) = @_;
+
+    croak "can't find empty command" unless length $cmd_name;
+
     if ( File::Spec->file_name_is_absolute($cmd_name) && -x $cmd_name ) {
         _debug "'", $cmd_name, "' is absolute"
           if _debugging_details;


### PR DESCRIPTION
Fixes #162.

This pull request currently contains 2 changes:

- `croak` on empty (or undefined) strings in `_search_path`
- `croak` on references to undefined arrays in `harness`
 
Any of the two would be sufficient on its own to solve this specific problem, but I suggest to go with both.

I think the first change is important because regardless of this issue, it is semantically incorrect to search for empty file names on a path. And the second change is important because if we know we are going to fail, it's better to fail fast. Of course, failing really fast would mean the very first line of `run`, but after studying the code a little, it felt like the correct place to handle such special cases is in `harness`.

Instead of failing silently I'm using `croak` in both cases, but I'm unsure if this is the correct decision, and would like to hear your input. I'm unsure, because this library has many users, and it is quite possible that someone has accidentally (or not) written code that depends on `run` not failing on undefined values. This fix would break such code. On the other hand, if your code accidentally depends on a bug, maybe you want it to break, so you notice the problem.

I would add some test, but to be perfectly honest, I have no idea how the test framework works.