### PR TITLE
Fix POD formatting

### DIFF
--- a/lib/IPC/Run.pm
+++ b/lib/IPC/Run.pm
@@ -3452,7 +3452,7 @@ be left in an unstable state, it's best to kill the harness to get rid
 of all the child processes, etc.
 
 Specifically, if a timeout expires in finish(), finish() will not
-kill all the children.  Call C<<$h->kill_kill>> in this case if you care.
+kill all the children.  Call C<< $h->kill_kill >> in this case if you care.
 This differs from the behavior of L</run>.
 
 =cut


### PR DESCRIPTION
As per [perlpod](https://perldoc.perl.org/perlpod#Formatting-Codes), "*Doubled angle brackets (`<<` and `>>`) may be used if and only if there is whitespace right after the opening delimiter and whitespace right before the closing delimiter!*"

Before:

```console
$ pod2text lib/IPC/Run.pm | grep -o 'Call .* in this case'
Call "<$h-"kill_kill>> in this case
```

After:

```console
$ pod2text lib/IPC/Run.pm | grep -o 'Call .* in this case'
Call "$h->kill_kill" in this case
```